### PR TITLE
Updated react peer dependency semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "webpack-dev-server": "^1.7.0"
   },
   "peerDependencies": {
-    "react": "^0.12.2"
+    "react": ">=0.12.2 <0.14.0"
   },
   "description": "A component to display React components with their JSX source in style guides",
   "directories": {


### PR DESCRIPTION
The react peerdependency semver is causing issues with react 0.13.x because it's using the caret
operator. The caret, in conjunction with a 0.x.0 semver will only satisfy a dependency of a patch up to but
not including the next minor version. In this case, react-style-guide started causing errors during install
as soon as  was published.

I updated the dependency so that react-style-guide will not throw errors as 1.0.x unless the installed version of react is 0.14.0 or g
reater
